### PR TITLE
削除テスト（提案）

### DIFF
--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -75,36 +75,55 @@ describe 'タスク管理機能', type: :system do
     end
   end
 
-  describe '削除機能' do
+  describe 'タスク編集機能' do
     let(:login_user) { user_a }
-    let(:task_name) { '削除用のテストを書く' }
+    let(:task_name) { '編集済タスク' }
 
     before do
-      visit new_task_path
+      visit task_path(task_a)
+      click_on '編集'
       fill_in '名称', with: task_name
-      click_button '登録する'
+      click_button '更新する'
     end
 
-    context '一覧画面で削除ボタンを押したとき' do
-      it 'タスクが正常に削除される' do
-        expect(page).to have_selector '.alert-success', text: '削除しました。'
-      end
-    end
-
-    context '詳細画面で削除ボタンを押したとき' do
-      it 'タスクが正常に削除される' do
-        # 詳細ページに遷移する
-        visit task_path(task_a)
-        # 削除ボタンを押す
-        click_button '削除'
-        # ダイアログのOKを押す
-        page.accept_confirm do
-          click_on 'OK'
-        end
-        # 「タスク「test」を削除しました。」というメッセージがあることを確認する
-        expect(page).to have_selector '.alert-success', text: '削除用のテストを書く'
+    context '名称を編集したとき' do
+      it '正常に登録される' do
+        expect(page).to have_selector '.alert-success', text: '更新しました'
       end
     end
   end
+
+  # 難しいため、一旦保留
+  # describe '削除機能' do
+  #   let(:login_user) { user_a }
+  #   let(:task_name) { '削除用のテストを書く' }
+  #
+  #   before do
+  #     visit new_task_path
+  #     fill_in '名称', with: task_name
+  #     click_button '登録する'
+  #   end
+  #
+  #   context '一覧画面で削除ボタンを押したとき' do
+  #     it 'タスクが正常に削除される' do
+  #       expect(page).to have_selector '.alert-success', text: '削除しました。'
+  #     end
+  #   end
+  #
+  #   context '詳細画面で削除ボタンを押したとき' do
+  #     it 'タスクが正常に削除される' do
+  #       # 詳細ページに遷移する
+  #       visit task_path(task_a)
+  #       # 削除ボタンを押す
+  #       click_button '削除'
+  #       # ダイアログのOKを押す
+  #       page.accept_confirm do
+  #         click_on 'OK'
+  #       end
+  #       # 「タスク「test」を削除しました。」というメッセージがあることを確認する
+  #       expect(page).to have_selector '.alert-success', text: '削除用のテストを書く'
+  #     end
+  #   end
+  # end
 
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -93,6 +93,24 @@ describe 'タスク管理機能', type: :system do
     end
   end
 
+  describe '削除機能' do
+    let(:login_user) { user_a }
+    let(:task_delete) { FactoryBot.create(:task, name: '削除用タスク', user: user_a) }
+
+    context '詳細画面で削除ボタンを押したとき' do
+      it 'タスクが正常に削除される' do
+        # 詳細ページに遷移する
+        visit task_path(task_delete)
+        # 削除ボタンを押す
+        click_on '削除'
+        # ダイアログのOKを押す
+        page.accept_confirm
+        # 「タスク「削除用タスク」を削除しました。」というメッセージがあることを確認する
+        expect(page).to have_selector '.alert-success', text: '削除用タスク'
+      end
+    end
+  end
+
   # 難しいため、一旦保留
   # describe '削除機能' do
   #   let(:login_user) { user_a }

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -74,4 +74,19 @@ describe 'タスク管理機能', type: :system do
       end
     end
   end
+
+  describe '削除機能' do
+    context '一覧画面で削除ボタンを押したとき' do
+      it 'タスクが正常に削除される' do
+        expect(page).to have_selector '.alert-success', text: '削除しました。'
+      end
+    end
+
+    context '詳細画面で削除ボタンを押したとき' do
+      it 'タスクが正常に削除される' do
+        #
+      end
+    end
+  end
+
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -76,6 +76,15 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '削除機能' do
+    let(:login_user) { user_a }
+    let(:task_name) { '削除用のテストを書く' }
+
+    before do
+      visit new_task_path
+      fill_in '名称', with: task_name
+      click_button '登録する'
+    end
+
     context '一覧画面で削除ボタンを押したとき' do
       it 'タスクが正常に削除される' do
         expect(page).to have_selector '.alert-success', text: '削除しました。'
@@ -84,7 +93,16 @@ describe 'タスク管理機能', type: :system do
 
     context '詳細画面で削除ボタンを押したとき' do
       it 'タスクが正常に削除される' do
-        #
+        # 詳細ページに遷移する
+        visit task_path(task_a)
+        # 削除ボタンを押す
+        click_button '削除'
+        # ダイアログのOKを押す
+        page.accept_confirm do
+          click_on 'OK'
+        end
+        # 「タスク「test」を削除しました。」というメッセージがあることを確認する
+        expect(page).to have_selector '.alert-success', text: '削除用のテストを書く'
       end
     end
   end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -97,14 +97,18 @@ describe 'タスク管理機能', type: :system do
     let(:login_user) { user_a }
     let(:task_delete) { FactoryBot.create(:task, name: '削除用タスク', user: user_a) }
 
-    context '詳細画面で削除ボタンを押したとき' do
-      it 'タスクが正常に削除される' do
-        # 詳細ページに遷移する
-        visit task_path(task_delete)
-        # 削除ボタンを押す
+    before do
+      # 詳細ページに遷移する
+      visit task_path(task_delete)
+      # 削除ボタンを押す
+      # ダイアログのOKを押す
+      page.accept_confirm do
         click_on '削除'
-        # ダイアログのOKを押す
-        page.accept_confirm
+      end
+    end
+
+    context '詳細画面から削除したとき' do
+      it 'タスクが正常に削除される' do
         # 「タスク「削除用タスク」を削除しました。」というメッセージがあることを確認する
         expect(page).to have_selector '.alert-success', text: '削除用タスク'
       end


### PR DESCRIPTION
削除機能テストが通るコードを見つけたので、共有のためにプルリクしました。反映するかどうかご判断はお任せします。
## ポイント
- beforeで新規作成したタスクを削除していなかった
    - →新規のタスクをletで作成した
- ダイアログのOKボタンが押せなかった
    - →page.accept_confirmのみで動く
    - →（または）
     ```ruby
        # 前の行で書かれている「click_on '削除'」を「accept_confirm」のブロック内にする
        page.accept_confirm do
          click_on '削除'
        end
    ```
    [Capybara でデータ削除時の confirm ボタンを押したい \- Just do IT](https://k-koh.hatenablog.com/entry/2020/08/21/225715)