### PR TITLE
【現場Rails5章 番外編】削除機能と更新機能のSystem Specを追加した

### DIFF
--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -78,6 +78,7 @@ describe 'タスク管理機能', type: :system do
   describe '削除機能' do
     let(:login_user) { user_a }
     let(:task_name) { '削除機能のテスト' }
+
     before do
       visit new_task_path
       fill_in '名称', with: task_name
@@ -85,6 +86,7 @@ describe 'タスク管理機能', type: :system do
       visit tasks_path
       click_link '削除機能のテスト'
     end
+
     context '一覧画面で削除ボタンを押したとき' do
       it 'タスクが正常に削除される' do
         accept_alert do
@@ -107,6 +109,7 @@ describe 'タスク管理機能', type: :system do
   describe '更新機能' do
     let(:login_user) { user_a }
     let(:task_name) { '削除機能のテスト' }
+
     before do
       visit new_task_path
       fill_in '名称', with: task_name

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -103,4 +103,23 @@ describe 'タスク管理機能', type: :system do
       end
     end
   end
+
+  describe '更新機能' do
+    let(:login_user) { user_a }
+    let(:task_name) { '削除機能のテスト' }
+    before do
+      visit new_task_path
+      fill_in '名称', with: task_name
+      click_button '登録する'
+      visit tasks_path
+      click_link '削除機能のテスト'
+    end
+
+    it 'タスクの更新ができる' do
+      click_on '編集'
+      fill_in '詳しい説明', with: 'updated!'
+      click_button '更新する'
+      expect(page).to have_selector '.alert-success', text: '削除機能のテスト'
+    end
+  end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -75,77 +75,32 @@ describe 'タスク管理機能', type: :system do
     end
   end
 
-  describe 'タスク編集機能' do
-    let(:login_user) { user_a }
-    let(:task_name) { '編集済タスク' }
-
-    before do
-      visit task_path(task_a)
-      click_on '編集'
-      fill_in '名称', with: task_name
-      click_button '更新する'
-    end
-
-    context '名称を編集したとき' do
-      it '正常に登録される' do
-        expect(page).to have_selector '.alert-success', text: '更新しました'
-      end
-    end
-  end
-
   describe '削除機能' do
     let(:login_user) { user_a }
-    let(:task_delete) { FactoryBot.create(:task, name: '削除用タスク', user: user_a) }
-
+    let(:task_name) { '削除機能のテスト' }
     before do
-      # 詳細ページに遷移する
-      visit task_path(task_delete)
-      # 削除ボタンを押す
-      # ダイアログのOKを押す
-      page.accept_confirm do
-        click_on '削除'
+      visit new_task_path
+      fill_in '名称', with: task_name
+      click_button '登録する'
+      visit tasks_path
+      click_link '削除機能のテスト'
+    end
+    context '一覧画面で削除ボタンを押したとき' do
+      it 'タスクが正常に削除される' do
+        accept_alert do
+          click_on '削除'
+        end
+        expect(page).to have_selector '.alert-success', text: '削除機能のテスト'
       end
     end
 
-    context '詳細画面から削除したとき' do
+    context '詳細画面で削除ボタンを押したとき' do
       it 'タスクが正常に削除される' do
-        # 「タスク「削除用タスク」を削除しました。」というメッセージがあることを確認する
-        expect(page).to have_selector '.alert-success', text: '削除用タスク'
+        accept_alert do
+          click_on '削除'
+        end
+        expect(page).to have_selector '.alert-success', text: '削除機能のテスト'
       end
     end
   end
-
-  # 難しいため、一旦保留
-  # describe '削除機能' do
-  #   let(:login_user) { user_a }
-  #   let(:task_name) { '削除用のテストを書く' }
-  #
-  #   before do
-  #     visit new_task_path
-  #     fill_in '名称', with: task_name
-  #     click_button '登録する'
-  #   end
-  #
-  #   context '一覧画面で削除ボタンを押したとき' do
-  #     it 'タスクが正常に削除される' do
-  #       expect(page).to have_selector '.alert-success', text: '削除しました。'
-  #     end
-  #   end
-  #
-  #   context '詳細画面で削除ボタンを押したとき' do
-  #     it 'タスクが正常に削除される' do
-  #       # 詳細ページに遷移する
-  #       visit task_path(task_a)
-  #       # 削除ボタンを押す
-  #       click_button '削除'
-  #       # ダイアログのOKを押す
-  #       page.accept_confirm do
-  #         click_on 'OK'
-  #       end
-  #       # 「タスク「test」を削除しました。」というメッセージがあることを確認する
-  #       expect(page).to have_selector '.alert-success', text: '削除用のテストを書く'
-  #     end
-  #   end
-  # end
-
 end


### PR DESCRIPTION
一応、パスするテストが書けたのでPR作りました。
未レビューなのでDRYなのはご愛嬌ってことで

@yatsuhashi168 このPRはマージはしなくて大丈夫です。

# 削除機能について

`accept_alert`のブロックに`click_on '削除'`を渡すことでダイアログのOKを押すという挙動をクリアする事ができました。
`accept_confirm`でもテスト通過しました。

日報に経緯が乗っているのでそちらも参照ください。
- [日報](https://bootcamp.fjord.jp/reports/42460)
- [accept_alertのドキュメント](https://www.rubydoc.info/gems/capybara/Capybara%2FSession:accept_alert)
- [accept_confirmのドキュメント](https://www.rubydoc.info/gems/capybara/Capybara/Session:accept_confirm)

# 更新機能

更新機能は難しいことはなく、新規作成と似た感じで書きました。

# スクリーンショット
![スクリーンショット 2021-12-01 11 37 50](https://user-images.githubusercontent.com/45246171/144161875-9f574bfc-27af-4a69-9b40-8ec5bb21739f.png)
